### PR TITLE
add dependency to nodes 1to1 [REVPI-3216]

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+noderedrevpinodes-server (1.0.5-1+revpi11+2) bullseye; urgency=medium
+
+  * packaging: Add dependency to node-red-contrib-revpi-nodes
+
+ -- Sven Sager <s.sager@kunbus.com>  Thu, 01 Jun 2023 13:45:35 +0200
+
 noderedrevpinodes-server (1.0.5-1+revpi11+1) bullseye; urgency=medium
 
   [ Dennis Filsinger ]

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,8 @@ Architecture: all
 Depends:
   ${misc:Depends},
   ${python3:Depends},
+  node-red-contrib-revpi-nodes (>= 1.1.0),
+  node-red-contrib-revpi-nodes (<< 1.1.1),
   python3-revpimodio2 (>= 2.5.1),
   python3-bcrypt (>= 3.1.2),
   python3-cryptography (>= 1.7.1),


### PR DESCRIPTION
The server must be installed with a specific version of the
node-red-contrib-revpi-nodes. This software is now being rolled out by
us as a Debian package. This now allows us to install together.