### PR TITLE
packaging(patch): Add support IPv6 for backend server

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+noderedrevpinodes-server (1.0.5-1+revpi11+3) bullseye; urgency=medium
+
+  * packaging(patch): Add support IPv6 for backend server
+
+ -- Sven Sager <s.sager@kunbus.com>  Sat, 03 Jun 2023 07:42:12 +0200
+
 noderedrevpinodes-server (1.0.5-1+revpi11+2) bullseye; urgency=medium
 
   * packaging: Add dependency to node-red-contrib-revpi-nodes

--- a/debian/patches/0003-feat-Support-IPv6-for-backend-server.patch
+++ b/debian/patches/0003-feat-Support-IPv6-for-backend-server.patch
@@ -1,0 +1,32 @@
+From: Nicolai Buchwitz <n.buchwitz@kunbus.com>
+Date: Thu, 1 Jun 2023 17:53:17 +0200
+Subject: feat: Support IPv6 for backend server
+
+It has been a while since IPv6 launch day 6.6.2012, so it the NodeRed backend
+should support IPv6 too. Nearly all systems default to IPv6 and also names like
+localhost are resolved to their IPv6 address by default. This means if a user
+enters localhost in NodeJS for the server config it will fail. Fix this by
+listen to IPv4 and IPv6.
+
+Signed-off-by: Nicolai Buchwitz <n.buchwitz@kunbus.com>
+(cherry picked from commit 889cd6347ddd12435e8c189a45bde531c6ebf82b)
+---
+ revpi-server.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/revpi-server.py b/revpi-server.py
+index 2467b76..a87c66c 100644
+--- a/revpi-server.py
++++ b/revpi-server.py
+@@ -199,9 +199,9 @@ class RevPiServer:
+         self.revpi.cycleloop(self.cyclefunc, cycletime=self.cycle_time_ms, blocking=False)
+ 
+     def start_websocket_loop(self):
+-        ip = '0.0.0.0'
++        ip = ['::', '0.0.0.0']
+         if self.block_external_connections:
+-            ip = '127.0.0.1'
++            ip = ['::1', '127.0.0.1']
+         if distro.codename() == 'stretch':
+             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS)
+             localhost_pem = os.path.abspath(self.cert_file)

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0001-Fix-client-version-check.patch
 0002-change-version-in-readme.patch
+0003-feat-Support-IPv6-for-backend-server.patch


### PR DESCRIPTION
We have to insert this patch via our packaging, because `localhost` (The default value in the revpi-nodes) is resolved to `::1`. As a result, NodeRED cannot connect to the server for the nodes.

Currently, we don't have time to wait for the new upstream version!